### PR TITLE
Pause timer on flagging response

### DIFF
--- a/src/components/FlagButton.tsx
+++ b/src/components/FlagButton.tsx
@@ -12,6 +12,7 @@ interface FlagButtonProps {
   isPracticeMode?: boolean;
   className?: string;
   questionType?: 'multiple-choice' | 'calculation' | 'input';
+  onPopupStateChange?: (isOpen: boolean) => void;
 }
 
 export default function FlagButton({ 
@@ -21,7 +22,8 @@ export default function FlagButton({
   questionText,
   isPracticeMode = false,
   className = '',
-  questionType
+  questionType,
+  onPopupStateChange
 }: FlagButtonProps) {
   const [showPopup, setShowPopup] = useState(false);
   const [reason, setReason] = useState('');
@@ -36,6 +38,7 @@ export default function FlagButton({
       setIsFlagged(false);
     } else {
       setShowPopup(true);
+      onPopupStateChange?.(true); // Notify parent that popup opened
     }
   };
 
@@ -45,12 +48,14 @@ export default function FlagButton({
       setIsFlagged(true);
       setShowPopup(false);
       setReason('');
+      onPopupStateChange?.(false); // Notify parent that popup closed
     }
   };
 
   const handleCancel = () => {
     setShowPopup(false);
     setReason('');
+    onPopupStateChange?.(false); // Notify parent that popup closed
   };
 
   // Suggestions rapides basées sur le type de question

--- a/src/components/ResponseOverlay.tsx
+++ b/src/components/ResponseOverlay.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import FlagButton from './FlagButton';
 
 interface ResponseOverlayProps {
@@ -38,6 +41,36 @@ export default function ResponseOverlay({
   isPracticeMode = false,
   questionType
 }: ResponseOverlayProps) {
+  const [isFlagPopupOpen, setIsFlagPopupOpen] = useState(false);
+  const [wasAutoPaused, setWasAutoPaused] = useState(false);
+
+  // Handle flag popup state changes
+  const handleFlagPopupStateChange = (isOpen: boolean) => {
+    setIsFlagPopupOpen(isOpen);
+    
+    if (isOpen && !isPaused) {
+      // Flag popup opened and timer is not already paused
+      // Auto-pause the timer
+      onTogglePause();
+      setWasAutoPaused(true);
+    } else if (!isOpen && wasAutoPaused) {
+      // Flag popup closed and we had auto-paused
+      // Resume the timer only if it was auto-paused by us
+      if (isPaused) {
+        onTogglePause();
+      }
+      setWasAutoPaused(false);
+    }
+  };
+
+  // Reset auto-pause tracking when overlay is hidden
+  useEffect(() => {
+    if (!show) {
+      setWasAutoPaused(false);
+      setIsFlagPopupOpen(false);
+    }
+  }, [show]);
+
   if (!show) return null;
 
   // Determine background color and text based on result type
@@ -71,6 +104,7 @@ export default function ResponseOverlay({
               isPracticeMode={isPracticeMode}
               questionType={questionType}
               className="!bg-black/20 hover:!bg-black/30"
+              onPopupStateChange={handleFlagPopupStateChange}
             />
           </div>
         )}
@@ -93,13 +127,16 @@ export default function ResponseOverlay({
         </div>
         <div className={`text-sm mb-6 ${isSkipped ? 'text-white/60' : isCorrect ? 'text-[#181c24]/60' : 'text-white/60'}`}>
           {isPaused ? (
-            <span>⏸️ Pause - Cliquez sur Suivant pour continuer</span>
+            <span>
+              ⏸️ Pause
+              {isFlagPopupOpen ? ' - En cours de signalement' : ' - Cliquez sur Suivant pour continuer'}
+            </span>
           ) : (
             <span>Question suivante dans {countdown} seconde{countdown !== 1 ? 's' : ''}</span>
           )}
         </div>
         <div className="flex gap-3 justify-center">
-          {!isPaused && (
+          {!isPaused && !isFlagPopupOpen && (
             <button
               onClick={onTogglePause}
               className={`px-4 py-2 rounded-lg font-semibold transition-colors ${


### PR DESCRIPTION
Pause the response overlay timer when the flagging popup is open to prevent accidental progression to the next question.