### PR TITLE
Fix unique letters in latex questions

### DIFF
--- a/AMELIORATIONS_LATEX_LETTRES_UNIQUES.md
+++ b/AMELIORATIONS_LATEX_LETTRES_UNIQUES.md
@@ -1,0 +1,66 @@
+# Améliorations du rendu LaTeX - Lettres uniques
+
+## Problème identifié
+Les lettres uniques dans les questions étaient converties en LaTeX de manière inappropriée, ce qui causait des problèmes d'affichage pour du texte français normal.
+
+## Solution implémentée
+
+### Modifications apportées dans `src/utils/mathRenderer.tsx`
+
+#### 1. **Patterns rendus plus restrictifs**
+- **Polynômes avec variables** : Nécessitent maintenant au moins 2 termes au lieu de capturer des lettres isolées
+- **Expressions avec coefficients** : Ne capturent que les expressions avec coefficients numériques (ex: `2x`, `3y²`)
+- **Équations complexes** : Nécessitent au moins 3 éléments mathématiques
+- **Intégrales** : Utilisent des limites de mots strictes pour éviter de capturer "int" dans des mots comme "Point"
+
+#### 2. **Nouveaux patterns ajoutés**
+- **Expressions avec produits scalaires** : `a·b + c·d`, `a×b - c×d`
+- **Expressions avec puissances et opérateurs** : `x² + 1`, `y³ - 2`
+- **Variables avec puissances** : `x²`, `y³`
+
+#### 3. **Patterns supprimés**
+- **Notations spéciales trop larges** : Pattern qui capturait des lettres isolées avec des symboles mathématiques
+
+## Résultats
+
+### ✅ Cas qui ne sont plus convertis en LaTeX (correct)
+- "Quelle est la réponse a ?"
+- "Choisissez entre a et b"
+- "La lettre c est correcte"
+- "Réponse d"
+- "Option e"
+- "Valeur g"
+- "Élément h"
+- "Item i"
+- "Choix j"
+
+### ✅ Cas qui sont toujours convertis en LaTeX (correct)
+- "Calculez 2x + 3y"
+- "Trouvez sin(x) + cos(y)"
+- "Évaluez √(x + 1)"
+- "Déterminez lim x→0"
+- "Calculez ∫ f(x) dx"
+- "Trouvez f(x) = 2x + 1"
+- "Calculez |a×b|"
+- "Évaluez (a+b)/(c+d)"
+
+### ⚠️ Cas restants à corriger
+1. **"Point f"** - Toujours capturé par le pattern des intégrales
+2. **"Résolvez x² + 1"** - Pas capturé par les patterns actuels
+3. **"Résolvez a·b + c·d"** - Pas capturé par les patterns actuels
+
+## Taux de réussite
+**85%** des tests passent maintenant (17/20), ce qui représente une amélioration significative du système.
+
+## Impact
+- **Amélioration majeure** : Les lettres uniques dans le texte français ne sont plus converties en LaTeX inappropriément
+- **Préservation des fonctionnalités** : Les expressions mathématiques complexes continuent d'être correctement converties
+- **Stabilité** : Le système reste robuste avec des fallbacks appropriés
+
+## Prochaines étapes recommandées
+1. Affiner le pattern des intégrales pour éviter "Point f"
+2. Ajuster les patterns pour capturer correctement "x² + 1" et "a·b + c·d"
+3. Tester avec plus de cas réels de questions éducatives
+
+## Fichiers modifiés
+- `src/utils/mathRenderer.tsx` - Refactoring complet des patterns de détection mathématique

--- a/src/utils/mathRenderer.tsx
+++ b/src/utils/mathRenderer.tsx
@@ -16,28 +16,36 @@ export function renderMathText(text: string) {
     /\blim\s*(?:_{[^}]*})?\s*[a-zA-Z0-9()/\s\-+*=<>]+/gi,
     // Sommations: ∑, sum, Σ avec indices
     /(?:∑|sum|Σ)\s*(?:_{[^}]*})?\s*(?:\^{[^}]*})?\s*[a-zA-Z0-9()/\s\-+*=<>]+/gi,
-    // Intégrales: ∫, int avec bornes
-    /(?:∫|int)\s*(?:_{[^}]*})?\s*(?:\^{[^}]*})?\s*[a-zA-Z0-9()/\s\-+*=<>dx]+/gi,
+    // Intégrales: ∫, int avec bornes (seulement si int est un mot complet)
+    /(?:∫|\bint\b)\s*(?:_{[^}]*})?\s*(?:\^{[^}]*})?\s*[a-zA-Z0-9()/\s\-+*=<>dx]+/gi,
     // Dérivées: d/dx, ∂/∂x, f'(x), etc.
     /(?:d\/d[a-zA-Z]|∂\/∂[a-zA-Z]|[a-zA-Z]'+\([^)]*\))/g,
     // Fonctions mathématiques définies: f(x) = expression, g(t) = expression, etc.
     /\b[a-zA-Z]+\s*\([^)]*\)\s*=\s*[a-zA-Z0-9()\s\-+*/\^]+/g,
-    // Polynômes avec variables: 3x + 5y + 1, 2x² - 3x + 1, etc.
-    /\b(?:\d*[a-zA-Z](?:\^\d+)?(?:\s*[+\-]\s*\d*[a-zA-Z](?:\^\d+)?)*|[a-zA-Z](?:\^\d+)?(?:\s*[+\-]\s*\d*[a-zA-Z](?:\^\d+)?)+)(?:\s*[+\-]\s*\d+)?\b/g,
+    // Expressions avec produits scalaires: a·b + c·d, a×b - c×d, etc.
+    /[a-zA-Z]\s*[·×]\s*[a-zA-Z](?:\s*[+\-]\s*[a-zA-Z]\s*[·×]\s*[a-zA-Z])+/g,
+    // Polynômes avec variables (au moins 2 termes): 3x + 5y, 2x² - 3x + 1, etc.
+    /\b(?:\d+[a-zA-Z](?:\^\d+)?(?:\s*[+\-]\s*\d*[a-zA-Z](?:\^\d+)?)+|[a-zA-Z](?:\^\d+)?(?:\s*[+\-]\s*\d*[a-zA-Z](?:\^\d+)?){2,})(?:\s*[+\-]\s*\d+)?\b/g,
+    // Expressions avec au moins un opérateur et des coefficients: 2x, 3y², etc. (seulement si coefficient numérique)
+    /\b\d+[a-zA-Z](?:\^\d+)?\b/g,
     // Racines complexes: √(...), sqrt(...) avec expressions
     /(?:√|sqrt)\s*\([^)]*[a-zA-Z+\-*/][^)]*\)/g,
     // Fractions complexes avec variables: (a+b)/(c+d), sin(x)/cos(x), etc.
     /\([^)]*[a-zA-Z][^)]*\)\s*\/\s*\([^)]*[a-zA-Z][^)]*\)/g,
     // Puissances avec expressions complexes: (a+b)^{n}, e^{-x}, etc.
     /(?:\([^)]*[a-zA-Z][^)]*\)|\b[a-zA-Z]+)\s*\^\s*\{[^}]*[a-zA-Z+\-*/][^}]*\}/g,
+    // Variables avec puissances: x², y³, etc.
+    /\b[a-zA-Z]\^\d+\b/g,
+    // Expressions avec puissances et opérateurs: x² + 1, y³ - 2, etc.
+    /[a-zA-Z]\^\d+\s*[+\-]\s*\d+/g,
     // Fonctions transcendantes avec arguments complexes: sin(2x+1), ln(x²+1), etc.
     /\b(?:sin|cos|tan|ln|log|exp|arcsin|arccos|arctan|sinh|cosh|tanh)\s*\([^)]*[a-zA-Z+\-*/\^][^)]*\)/gi,
-    // Équations et inéquations complexes avec plusieurs termes
-    /[a-zA-Z0-9()\s\-+*/\^]+\s*(?:=|≠|<|>|≤|≥|≡)\s*[a-zA-Z0-9()\s\-+*/\^]*[a-zA-Z()\^][a-zA-Z0-9()\s\-+*/\^]*/g,
+    // Équations complexes avec au moins 3 éléments mathématiques
+    /(?:[a-zA-Z0-9()\^\s\-+*/]{3,})\s*(?:=|≠|<|>|≤|≥|≡)\s*(?:[a-zA-Z0-9()\^\s\-+*/]{3,})/g,
     // Matrices et vecteurs avec notation complexe: |a×b|, det(A), etc.
     /(?:\|[^|]*[a-zA-Z×\s+\-*/][^|]*\||det\s*\([^)]*\)|tr\s*\([^)]*\))/g,
-    // Produits scalaires et vectoriels complexes: a⃗·b⃗, a×b, etc.
-    /[a-zA-Z]\s*(?:⃗|vec)\s*[·×]\s*[a-zA-Z]\s*(?:⃗|vec)|[a-zA-Z]\s*[·×]\s*[a-zA-Z]/g,
+    // Produits scalaires et vectoriels avec notation vectorielle: a⃗·b⃗, vec(a)×vec(b), etc.
+    /(?:[a-zA-Z]\s*(?:⃗|vec)\s*[·×]\s*[a-zA-Z]\s*(?:⃗|vec)|vec\s*\([^)]+\)\s*[·×]\s*vec\s*\([^)]+\))/g,
   ];
 
   // Collecter toutes les expressions mathématiques


### PR DESCRIPTION
Refine LaTeX detection patterns to prevent incorrect conversion of single letters in questions.

Previously, the patterns in `src/utils/mathRenderer.tsx` were too broad, causing single letters in normal text to be incorrectly rendered as LaTeX. This PR introduces more restrictive and specific regular expressions, significantly improving the accuracy of LaTeX detection for mathematical expressions while preserving plain text. Although 85% of test cases now pass, a few edge cases are noted for future refinement.